### PR TITLE
Relp

### DIFF
--- a/salt/serversetup.sh
+++ b/salt/serversetup.sh
@@ -83,13 +83,24 @@ DNS.3 = https://logserver.local" >> logserver.local.ext
 # Sign the CSR
 openssl x509 -req -in logserver.local.csr -CA localCA.pem -CAkey localCA.key -CAcreateserial -out logserver.local.crt -days 1825 -sha256 -extfile logserver.local.ext -passin pass:$ssl_pass
 
+## Copy certificates to /etc/ssl
+cp localCA.pem /etc/ssl
+cp logserver.local.crt /etc/ssl
+cp logserver.local.key /etc/ssl
+
+## Create client certificate, just like above
+openssl genrsa -out logclient.local.key 2048
+openssl req -new -key logclient.local.key -out logclient.local.csr -subj "/C=FI/ST=Uusimaa/L=Helsinki/O=Haaga-Helia/OU=Logserver/CN=logclient.local"
+openssl x509 -req -in logclient.local.csr -CA localCA.pem -CAkey localCA.key -CAcreateserial -out logclient.local.crt -days 1825 -sha256 -passin pass:$ssl_pass
+
+## Copy client keys for salt distribution
+cp localCA.pem /srv/salt/rsyslog-client/
+cp logclient.local.crt /srv/salt/rsyslog-client/
+cp logclient.local.key /srv/salt/rsyslog-client/
+
 # Convert certificate into PKCS12 for Firefox import
 # CURRENTLY BROKEN
 # openssl pkcs12 -export -out logserver.local.pfx -inkey logserver.local.key -in logserver.local.crt -certfile localCA.crt
-
-## Copy certificates to /etc/ssl
-cp logserver.local.crt /etc/ssl/certs/
-cp logserver.local.key /etc/ssl/private/
 
 ## Import root CA to Firefox
 # Need to find the random-generated alphanumeric 

--- a/salt/serversetup.sh
+++ b/salt/serversetup.sh
@@ -87,6 +87,8 @@ openssl x509 -req -in logserver.local.csr -CA localCA.pem -CAkey localCA.key -CA
 cp localCA.pem /etc/ssl
 cp logserver.local.crt /etc/ssl
 cp logserver.local.key /etc/ssl
+cp logserver.local.crt /etc/ssl/certs/
+cp logserver.local.key /etc/ssl/private/
 
 ## Create client certificate, just like above
 openssl genrsa -out logclient.local.key 2048

--- a/salt/srvpillar/rsyslog.sls
+++ b/salt/srvpillar/rsyslog.sls
@@ -1,1 +1,2 @@
 rsyslog_port: 514
+relp_port: 10514

--- a/salt/srvsalt/fixperms.sls
+++ b/salt/srvsalt/fixperms.sls
@@ -12,3 +12,8 @@
       - user
       - group
       - mode
+
+sched_perms:
+  schedule.present:
+    - function: fixperms.sls
+    - seconds: 60

--- a/salt/srvsalt/rsyslog-client/init.sls
+++ b/salt/srvsalt/rsyslog-client/init.sls
@@ -12,6 +12,18 @@ rsyslog.install:
     - context:
       rsyslog_ip: {{salt['grains.get']('master')}}
       relp_port: {{pillar.get('relp_port', '10514')}}
+      
+/etc/ssl/localCA.pem:
+  file.managed:
+    - source: salt://rsyslog-client/localCA.pem
+
+/etc/ssl/logclient.local.key:
+  file.managed:
+    - source: salt://rsyslog-client/logclient.local.key
+    
+/etc/ssl/logclient.local.crt:
+  file.managed:
+    - source: salt://rsyslog-client/logclient.local.crt
 
 rsyslog.service:
   service.running:

--- a/salt/srvsalt/rsyslog-client/init.sls
+++ b/salt/srvsalt/rsyslog-client/init.sls
@@ -1,5 +1,9 @@
-rsyslog:
-  pkg.latest
+rsyslog.install:
+  pkg.latest:
+    - pkgs:
+      - rsyslog
+      - rsyslog-relp
+      - librelp-dev
 
 /etc/rsyslog.conf:
   file.managed:

--- a/salt/srvsalt/rsyslog-client/init.sls
+++ b/salt/srvsalt/rsyslog-client/init.sls
@@ -11,7 +11,7 @@ rsyslog.install:
     - template: jinja
     - context:
       rsyslog_ip: {{salt['grains.get']('master')}}
-      rsyslog_port: {{pillar.get('rsyslog_port', '514')}}
+      relp_port: {{pillar.get('relp_port', '10514')}}
 
 rsyslog.service:
   service.running:

--- a/salt/srvsalt/rsyslog-client/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-client/rsyslog.conf
@@ -6,7 +6,7 @@ module(load="imklog")
 module(load="omrelp")
 
 *.* action(type="omrelp" target="{{rsyslog_ip}}"
-port="10514" tls="on"
+port="{{relp_port}}" tls="on"
 tls.caCert="/etc/ssl/localCA.pem"
 tls.myCert="/etc/ssl/logclient1.local.crt"
 tls.myPrivKey="/etc/ssl/logclient1.local.key"

--- a/salt/srvsalt/rsyslog-client/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-client/rsyslog.conf
@@ -8,10 +8,10 @@ module(load="omrelp")
 *.* action(type="omrelp" target="{{rsyslog_ip}}"
 port="10514" tls="on"
 tls.caCert="/etc/ssl/localCA.pem"
-tls.myCert="/etc/ssl/clientname.crt"
-tls.myPrivKey="/etc/ssl/clientname.key"
+tls.myCert="/etc/ssl/logclient1.local.crt"
+tls.myPrivKey="/etc/ssl/logclient1.local.key"
 tls.authmode="name"
-tls.permittedpeer=["logserver.local","{{rsyslog_ip}}"]
+tls.permittedpeer=["logserver.local"]
 )
 
 #*.* @@{{rsyslog_ip}}:{{rsyslog_port}}

--- a/salt/srvsalt/rsyslog-client/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-client/rsyslog.conf
@@ -8,8 +8,8 @@ module(load="omrelp")
 *.* action(type="omrelp" target="{{rsyslog_ip}}"
 port="{{relp_port}}" tls="on"
 tls.caCert="/etc/ssl/localCA.pem"
-tls.myCert="/etc/ssl/logclient1.local.crt"
-tls.myPrivKey="/etc/ssl/logclient1.local.key"
+tls.myCert="/etc/ssl/logclient.local.crt"
+tls.myPrivKey="/etc/ssl/logclient.local.key"
 tls.authmode="name"
 tls.permittedpeer=["logserver.local"]
 )

--- a/salt/srvsalt/rsyslog-client/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-client/rsyslog.conf
@@ -3,8 +3,18 @@
 
 module(load="imuxsock") # provides support for local system logging
 module(load="imklog")   # provides kernel logging support
+module(load="omrelp")
 
-*.* @@{{rsyslog_ip}}:{{rsyslog_port}}
+*.* action(type="omrelp" target="{{rsyslog_ip}}"
+port="10514" tls="on"
+tls.caCert="/etc/ssl/localCA.pem"
+tls.myCert="/etc/ssl/clientname.crt"
+tls.myPrivKey="/etc/ssl/clientname.key"
+tls.authmode="name"
+tls.permittedpeer=["logserver.local","{{rsyslog_ip}}"]
+)
+
+#*.* @@{{rsyslog_ip}}:{{rsyslog_port}}
 
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 

--- a/salt/srvsalt/rsyslog-client/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-client/rsyslog.conf
@@ -1,8 +1,8 @@
 ## THIS IS A CENTRALLY MANAGED FILE! ##
 ##    CHANGES WILL BE OVERWRITTEN    ##
 
-module(load="imuxsock") # provides support for local system logging
-module(load="imklog")   # provides kernel logging support
+module(load="imuxsock")
+module(load="imklog")
 module(load="omrelp")
 
 *.* action(type="omrelp" target="{{rsyslog_ip}}"
@@ -13,8 +13,6 @@ tls.myPrivKey="/etc/ssl/logclient1.local.key"
 tls.authmode="name"
 tls.permittedpeer=["logserver.local"]
 )
-
-#*.* @@{{rsyslog_ip}}:{{rsyslog_port}}
 
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 

--- a/salt/srvsalt/rsyslog-pkg.sls
+++ b/salt/srvsalt/rsyslog-pkg.sls
@@ -2,8 +2,6 @@ rsyslog-pkg:
   pkgrepo.managed:
     - humanname: Rsyslog Repository
     - ppa: adiscon/v8-stable
-    - keyserver: keys.gnupg.net
-    - keyid: AEF0CF8E
     - refresh_db: true
     - require_in:
       - rsyslog-client

--- a/salt/srvsalt/rsyslog-server/init.sls
+++ b/salt/srvsalt/rsyslog-server/init.sls
@@ -1,5 +1,9 @@
-rsyslog:
-  pkg.latest
+rsyslog.install:
+  pkg.latest:
+    - pkgs:
+      - rsyslog
+      - rsyslog-relp
+      - librelp-dev
 
 /etc/rsyslog.conf:
   file.managed:

--- a/salt/srvsalt/rsyslog-server/init.sls
+++ b/salt/srvsalt/rsyslog-server/init.sls
@@ -10,7 +10,7 @@ rsyslog.install:
     - source: salt://rsyslog-server/rsyslog.conf
     - template: jinja
     - context:
-      rsyslog_port: {{pillar.get('relp_port','10514')}}
+      relp_port: {{pillar.get('relp_port','10514')}}
 
 syslog.user:
   user.present:

--- a/salt/srvsalt/rsyslog-server/init.sls
+++ b/salt/srvsalt/rsyslog-server/init.sls
@@ -10,7 +10,7 @@ rsyslog.install:
     - source: salt://rsyslog-server/rsyslog.conf
     - template: jinja
     - context:
-      rsyslog_port: {{pillar.get('rsyslog_port','514')}}
+      rsyslog_port: {{pillar.get('relp_port','10514')}}
 
 syslog.user:
   user.present:

--- a/salt/srvsalt/rsyslog-server/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-server/rsyslog.conf
@@ -9,6 +9,7 @@ tls.caCert="/etc/ssl/localCA.pem"
 tls.myCert="/etc/ssl/logserver.local.crt"
 tls.myPrivKey="/etc/ssl/logserver.local.key"
 tls.authMode="name"
+tls.permittedpeer=["logclient.local"]
 )
 
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat

--- a/salt/srvsalt/rsyslog-server/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-server/rsyslog.conf
@@ -3,7 +3,17 @@
 
 #module(load="omelasticsearch")
 module(load="imtcp")
-input(type="imtcp" port="{{rsyslog_port}}")
+module(load="imrelp")
+
+#input(type="imtcp" port="{{rsyslog_port}}")
+
+input(type="imrelp" port="10514" tls="on"
+tls.caCert="/etc/ssl/localCA.pem"
+tls.myCert="/etc/ssl/logserver.local.crt"
+tls.myPrivKey="/etc/ssl/logserver.local.key"
+tls.authMode="name"
+)
+
 #$AllowedSender TCP, 172.28.0.0/16, *.tielab.haaga-helia.fi
 
 # Enable non-kernel facility klog messages

--- a/salt/srvsalt/rsyslog-server/rsyslog.conf
+++ b/salt/srvsalt/rsyslog-server/rsyslog.conf
@@ -2,29 +2,19 @@
 ##    CHANGES WILL BE OVERWRITTEN    ##
 
 #module(load="omelasticsearch")
-module(load="imtcp")
 module(load="imrelp")
 
-#input(type="imtcp" port="{{rsyslog_port}}")
-
-input(type="imrelp" port="10514" tls="on"
+input(type="imrelp" port="{{relp_port}}" tls="on"
 tls.caCert="/etc/ssl/localCA.pem"
 tls.myCert="/etc/ssl/logserver.local.crt"
 tls.myPrivKey="/etc/ssl/logserver.local.key"
 tls.authMode="name"
 )
 
-#$AllowedSender TCP, 172.28.0.0/16, *.tielab.haaga-helia.fi
-
-# Enable non-kernel facility klog messages
-#$KLogPermitNonKernelFacility on
-
-# To enable high precision timestamps, comment out the following line.
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 $RepeatedMsgReduction on
 
-# Set the default permissions for all log files.
 $FileOwner syslog
 $FileGroup adm
 $FileCreateMode 0640
@@ -33,12 +23,9 @@ $Umask 0000
 $PrivDropToUser syslog
 $PrivDropToGroup adm
 
-# Where to place spool and state files
 $WorkDirectory /var/spool/rsyslog
 
-# Include all config files in /etc/rsyslog.d/
 $IncludeConfig /etc/rsyslog.d/*.conf
 
-## Split received logs into folders
 $template TmplMsg, "/var/log/client_logs/%HOSTNAME%-%FROMHOST-IP%/%PROGRAMNAME%.log"
 *.* action(type="omfile" dynaFile="TmplMsg")

--- a/salt/srvsalt/ufw/init.sls
+++ b/salt/srvsalt/ufw/init.sls
@@ -16,6 +16,7 @@ ufw:
       nginx_port: {{pillar.get('nginx_port','80')}}
       ssh_port: {{pillar.get('ssh_port','22')}}
       ssl_port: {{pillar.get('ssl_port','443')}}
+      relp_port: {{pillar.get('relp_port','10514')}}
 
 ufw.service:
   service.running:

--- a/salt/srvsalt/ufw/user.rules
+++ b/salt/srvsalt/ufw/user.rules
@@ -44,6 +44,9 @@
 ### tuple ### allow tcp 9300 0.0.0.0/0 any 127.0.0.1 in
 -A ufw-user-input -p tcp --dport 9300 -s 127.0.0.1 -j ACCEPT
 
+### tuple ### allow tcp 10514 0.0.0.0/0 any 172.28.0.0/16 in
+-A ufw-user-input -p tcp --dport 10514 -s 172.28.0.0/16 -j ACCEPT
+
 ### END RULES ###
 
 ### LOGGING ###

--- a/salt/srvsalt/ufw/user.rules
+++ b/salt/srvsalt/ufw/user.rules
@@ -44,8 +44,8 @@
 ### tuple ### allow tcp 9300 0.0.0.0/0 any 127.0.0.1 in
 -A ufw-user-input -p tcp --dport 9300 -s 127.0.0.1 -j ACCEPT
 
-### tuple ### allow tcp 10514 0.0.0.0/0 any 172.28.0.0/16 in
--A ufw-user-input -p tcp --dport 10514 -s 172.28.0.0/16 -j ACCEPT
+### tuple ### allow tcp {{relp_port}} 0.0.0.0/0 any 172.28.0.0/16 in
+-A ufw-user-input -p tcp --dport {{relp_port}} -s 172.28.0.0/16 -j ACCEPT
 
 ### END RULES ###
 


### PR DESCRIPTION
**This branch adds RELP encoding.**
* Traffic between Rsyslog client and server is encoded
* The encoding uses 2048-bit keys
* The keys and certificates are generated with a Certificate Authority
  * This enables two-way trust, since both endpoints are verified by the same upper trust
  * Clients are identified with the name specified within the certificate
  * Client identity is verified via the certificates
* Certificate generation is automated within the server setup script
**NOTE: Current configuration *only allows a single client*, since the certificates are generated within the setup script.**